### PR TITLE
Make Result a monad, simplify mapn implementations

### DIFF
--- a/ClientTemplate/src/Utils/Utils.elm
+++ b/ClientTemplate/src/Utils/Utils.elm
@@ -19,7 +19,7 @@ rMap2 = Result.map2
 rMap3 = Result.map3
 rMap4 = Result.map4
 rMap5 = Result.map5
-
+        
 rMap6 : (a -> b -> c -> d -> e -> f -> value) -> Result x a -> Result x b -> Result x c -> Result x d -> Result x e -> Result x f -> Result x value
 rMap6 fn ra rb rc rd re rf =
     case ra of 
@@ -185,6 +185,156 @@ rMap10 fn ra rb rc rd re rf rg rh ri rj =
                                                                                 Err x -> Err x
                                                                                 Ok j -> Ok <| fn a b c d e f g h i j
 
+rMap11 : (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> k -> value)
+      -> Result x a
+      -> Result x b
+      -> Result x c
+      -> Result x d
+      -> Result x e
+      -> Result x f
+      -> Result x g
+      -> Result x h
+      -> Result x i
+      -> Result x j
+      -> Result x k    
+      -> Result x value
+rMap11 fn r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 =
+    r1 |> Result.andThen (\ok1 -> r2
+       |> Result.andThen (\ok2 -> r3
+       |> Result.andThen (\ok3 -> r4
+       |> Result.andThen (\ok4 -> r5
+       |> Result.andThen (\ok5 -> r6
+       |> Result.andThen (\ok6 -> r7
+       |> Result.andThen (\ok7 -> r8
+       |> Result.andThen (\ok8 -> r9
+       |> Result.andThen (\ok9 -> r10
+       |> Result.andThen (\ok10 -> r11
+       |> Result.andThen (\ok11 -> Ok <| fn ok1 ok2 ok3 ok4 ok5 ok6 ok7 ok8 ok9 ok10 ok11)))))))))))
+
+rMap12 : (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> k -> l -> value)
+      -> Result x a
+      -> Result x b
+      -> Result x c
+      -> Result x d
+      -> Result x e
+      -> Result x f
+      -> Result x g
+      -> Result x h
+      -> Result x i
+      -> Result x j
+      -> Result x k
+      -> Result x l   
+      -> Result x value
+rMap12 fn r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 =
+    r1 |> Result.andThen (\ok1 -> r2
+       |> Result.andThen (\ok2 -> r3
+       |> Result.andThen (\ok3 -> r4
+       |> Result.andThen (\ok4 -> r5
+       |> Result.andThen (\ok5 -> r6
+       |> Result.andThen (\ok6 -> r7
+       |> Result.andThen (\ok7 -> r8
+       |> Result.andThen (\ok8 -> r9
+       |> Result.andThen (\ok9 -> r10
+       |> Result.andThen (\ok10 -> r11
+       |> Result.andThen (\ok11 -> r12
+       |> Result.andThen (\ok12 -> Ok <| fn ok1 ok2 ok3 ok4 ok5 ok6 ok7 ok8 ok9 ok10 ok11 ok12))))))))))))
+        
+rMap13 : (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> k -> l -> m -> value)
+      -> Result x a
+      -> Result x b
+      -> Result x c
+      -> Result x d
+      -> Result x e
+      -> Result x f
+      -> Result x g
+      -> Result x h
+      -> Result x i
+      -> Result x j
+      -> Result x k
+      -> Result x l
+      -> Result x m       
+      -> Result x value
+rMap13 fn r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 =
+    r1 |> Result.andThen (\ok1 -> r2
+       |> Result.andThen (\ok2 -> r3
+       |> Result.andThen (\ok3 -> r4
+       |> Result.andThen (\ok4 -> r5
+       |> Result.andThen (\ok5 -> r6
+       |> Result.andThen (\ok6 -> r7
+       |> Result.andThen (\ok7 -> r8
+       |> Result.andThen (\ok8 -> r9
+       |> Result.andThen (\ok9 -> r10
+       |> Result.andThen (\ok10 -> r11
+       |> Result.andThen (\ok11 -> r12
+       |> Result.andThen (\ok12 -> r13
+       |> Result.andThen (\ok13 -> Ok <| fn ok1 ok2 ok3 ok4 ok5 ok6 ok7 ok8 ok9 ok10 ok11 ok12 ok13)))))))))))))
+
+rMap14 : (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> k -> l -> m -> n -> value)
+      -> Result x a
+      -> Result x b
+      -> Result x c
+      -> Result x d
+      -> Result x e
+      -> Result x f
+      -> Result x g
+      -> Result x h
+      -> Result x i
+      -> Result x j
+      -> Result x k
+      -> Result x l
+      -> Result x m
+      -> Result x n
+      -> Result x value
+rMap14 fn r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14 =
+    r1 |> Result.andThen (\ok1 -> r2
+       |> Result.andThen (\ok2 -> r3
+       |> Result.andThen (\ok3 -> r4
+       |> Result.andThen (\ok4 -> r5
+       |> Result.andThen (\ok5 -> r6
+       |> Result.andThen (\ok6 -> r7
+       |> Result.andThen (\ok7 -> r8
+       |> Result.andThen (\ok8 -> r9
+       |> Result.andThen (\ok9 -> r10
+       |> Result.andThen (\ok10 -> r11
+       |> Result.andThen (\ok11 -> r12
+       |> Result.andThen (\ok12 -> r13
+       |> Result.andThen (\ok13 -> r14                              
+       |> Result.andThen (\ok14 -> Ok <| fn ok1 ok2 ok3 ok4 ok5 ok6 ok7 ok8 ok9 ok10 ok11 ok12 ok13 ok14))))))))))))))
+
+rMap15 : (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> k -> l -> m -> n -> o -> value)
+      -> Result x a
+      -> Result x b
+      -> Result x c
+      -> Result x d
+      -> Result x e
+      -> Result x f
+      -> Result x g
+      -> Result x h
+      -> Result x i
+      -> Result x j
+      -> Result x k
+      -> Result x l
+      -> Result x m
+      -> Result x n
+      -> Result x o
+      -> Result x value
+rMap15 fn r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14 r15 =
+    r1 |> Result.andThen (\ok1 -> r2
+       |> Result.andThen (\ok2 -> r3
+       |> Result.andThen (\ok3 -> r4
+       |> Result.andThen (\ok4 -> r5
+       |> Result.andThen (\ok5 -> r6
+       |> Result.andThen (\ok6 -> r7
+       |> Result.andThen (\ok7 -> r8
+       |> Result.andThen (\ok8 -> r9
+       |> Result.andThen (\ok9 -> r10
+       |> Result.andThen (\ok10 -> r11
+       |> Result.andThen (\ok11 -> r12
+       |> Result.andThen (\ok12 -> r13
+       |> Result.andThen (\ok13 -> r14
+       |> Result.andThen (\ok14 -> r15                   
+       |> Result.andThen (\ok15 -> Ok <| fn ok1 ok2 ok3 ok4 ok5 ok6 ok7 ok8 ok9 ok10 ok11 ok12 ok13 ok14 ok15)))))))))))))))
+                              
 encodeInt : Int -> Int -> Int -> String
 encodeInt low high n =
     let

--- a/ServerTemplate/src/Static/Result.hs
+++ b/ServerTemplate/src/Static/Result.hs
@@ -25,6 +25,12 @@ map fn ra =
         Err x -> Err x
         Ok a -> Ok $ fn a
 
+mapError :: (x -> y) -> Result x a -> Result y a
+mapError fn rx =
+    case rx of
+        Ok a -> Ok a
+        Err x -> Err $ fn x 
+
 map1 :: (a -> value) -> Result x a -> Result x value
 map1 = Static.Result.map
 

--- a/ServerTemplate/src/Static/Result.hs
+++ b/ServerTemplate/src/Static/Result.hs
@@ -7,6 +7,17 @@ data Result err ok =
     | Err err
     deriving(Eq,Ord,Show)
 
+instance Functor (Result err) where
+    fmap = Static.Result.map
+
+instance Applicative (Result err) where
+    pure res = Ok res
+    Err err <*> _ = Err err
+    Ok f <*> r = fmap f r
+
+instance Monad (Result err) where
+   return = pure
+   (>>=) = flip Static.Result.andThen
 
 map :: (a -> value) -> Result x a -> Result x value
 map fn ra =
@@ -19,103 +30,22 @@ map1 = Static.Result.map
 
 
 map2 :: (a -> b -> value) -> Result x a -> Result x b -> Result x value
-map2 fn ra rb =
-    case ra of 
-        Err x -> Err x
-        Ok a -> 
-            case rb of 
-                Err x -> Err x
-                Ok b -> Ok $ fn a b
+map2 fn ra rb = fn <$> ra <*> rb
 
 map3 :: (a -> b -> c -> value) -> Result x a -> Result x b -> Result x c -> Result x value
-map3 fn ra rb rc =
-    case ra of 
-        Err x -> Err x
-        Ok a -> 
-            case rb of 
-                Err x -> Err x
-                Ok b ->
-                    case rc of 
-                        Err x -> Err x
-                        Ok c -> Ok $ fn a b c
+map3 fn ra rb rc = fn <$> ra <*> rb <*> rc
 
 map4 :: (a -> b -> c -> d -> value) -> Result x a -> Result x b -> Result x c -> Result x d -> Result x value
-map4 fn ra rb rc rd =
-    case ra of 
-        Err x -> Err x
-        Ok a -> 
-            case rb of 
-                Err x -> Err x
-                Ok b ->
-                    case rc of 
-                        Err x -> Err x
-                        Ok c -> 
-                            case rd of 
-                                Err x -> Err x
-                                Ok d -> Ok $ fn a b c d
+map4 fn ra rb rc rd = fn <$> ra <*> rb <*> rc <*> rd
 
 map5 :: (a -> b -> c -> d -> e -> value) -> Result x a -> Result x b -> Result x c -> Result x d -> Result x e -> Result x value
-map5 fn ra rb rc rd re =
-    case ra of 
-        Err x -> Err x
-        Ok a -> 
-            case rb of 
-                Err x -> Err x
-                Ok b ->
-                    case rc of 
-                        Err x -> Err x
-                        Ok c -> 
-                            case rd of 
-                                Err x -> Err x
-                                Ok d -> 
-                                    case re of 
-                                        Err x -> Err x
-                                        Ok e -> Ok $ fn a b c d e
+map5 fn ra rb rc rd re = fn <$> ra <*> rb <*> rc <*> rd <*> re
 
 map6 :: (a -> b -> c -> d -> e -> f -> value) -> Result x a -> Result x b -> Result x c -> Result x d -> Result x e -> Result x f -> Result x value
-map6 fn ra rb rc rd re rf =
-    case ra of 
-        Err x -> Err x
-        Ok a -> 
-            case rb of 
-                Err x -> Err x
-                Ok b ->
-                    case rc of 
-                        Err x -> Err x
-                        Ok c -> 
-                            case rd of 
-                                Err x -> Err x
-                                Ok d -> 
-                                    case re of 
-                                        Err x -> Err x
-                                        Ok e ->
-                                            case rf of 
-                                                Err x -> Err x
-                                                Ok f -> Ok $ fn a b c d e f
+map6 fn ra rb rc rd re rf = fn <$> ra <*> rb <*> rc <*> rd <*> re <*> rf
 
 map7 :: (a -> b -> c -> d -> e -> f -> g -> value) -> Result x a -> Result x b -> Result x c -> Result x d -> Result x e -> Result x f -> Result x g -> Result x value
-map7 fn ra rb rc rd re rf rg =
-    case ra of 
-        Err x -> Err x
-        Ok a -> 
-            case rb of 
-                Err x -> Err x
-                Ok b ->
-                    case rc of 
-                        Err x -> Err x
-                        Ok c -> 
-                            case rd of 
-                                Err x -> Err x
-                                Ok d -> 
-                                    case re of 
-                                        Err x -> Err x
-                                        Ok e ->
-                                            case rf of 
-                                                Err x -> Err x
-                                                Ok f -> 
-                                                    case rg of 
-                                                        Err x -> Err x
-                                                        Ok g -> Ok $ fn a b c d e f g
+map7 fn ra rb rc rd re rf rg = fn <$> ra <*> rb <*> rc <*> rd <*> re <*> rf <*> rg
 
 map8 :: (a -> b -> c -> d -> e -> f -> g -> h -> value)
       -> Result x a
@@ -127,31 +57,7 @@ map8 :: (a -> b -> c -> d -> e -> f -> g -> h -> value)
       -> Result x g
       -> Result x h 
       -> Result x value
-map8 fn ra rb rc rd re rf rg rh =
-    case ra of 
-        Err x -> Err x
-        Ok a -> 
-            case rb of 
-                Err x -> Err x
-                Ok b ->
-                    case rc of 
-                        Err x -> Err x
-                        Ok c -> 
-                            case rd of 
-                                Err x -> Err x
-                                Ok d -> 
-                                    case re of 
-                                        Err x -> Err x
-                                        Ok e ->
-                                            case rf of 
-                                                Err x -> Err x
-                                                Ok f -> 
-                                                    case rg of 
-                                                        Err x -> Err x
-                                                        Ok g ->
-                                                            case rh of 
-                                                                Err x -> Err x
-                                                                Ok h -> Ok $ fn a b c d e f g h
+map8 fn ra rb rc rd re rf rg rh = fn <$> ra <*> rb <*> rc <*> rd <*> re <*> rf <*> rg <*> rh
 
 map9 :: (a -> b -> c -> d -> e -> f -> g -> h -> i -> value)
       -> Result x a
@@ -164,34 +70,7 @@ map9 :: (a -> b -> c -> d -> e -> f -> g -> h -> i -> value)
       -> Result x h
       -> Result x i
       -> Result x value
-map9 fn ra rb rc rd re rf rg rh ri =
-    case ra of 
-        Err x -> Err x
-        Ok a -> 
-            case rb of 
-                Err x -> Err x
-                Ok b ->
-                    case rc of 
-                        Err x -> Err x
-                        Ok c -> 
-                            case rd of 
-                                Err x -> Err x
-                                Ok d -> 
-                                    case re of 
-                                        Err x -> Err x
-                                        Ok e ->
-                                            case rf of 
-                                                Err x -> Err x
-                                                Ok f -> 
-                                                    case rg of 
-                                                        Err x -> Err x
-                                                        Ok g ->
-                                                            case rh of 
-                                                                Err x -> Err x
-                                                                Ok h ->
-                                                                    case ri of 
-                                                                        Err x -> Err x
-                                                                        Ok i -> Ok $ fn a b c d e f g h i
+map9 fn ra rb rc rd re rf rg rh ri = fn <$> ra <*> rb <*> rc <*> rd <*> re <*> rf <*> rg <*> rh <*> ri
 
 map10 :: (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> value)
       -> Result x a
@@ -206,37 +85,22 @@ map10 :: (a -> b -> c -> d -> e -> f -> g -> h -> i -> j -> value)
       -> Result x j
       -> Result x value
 map10 fn ra rb rc rd re rf rg rh ri rj =
-    case ra of 
-        Err x -> Err x
-        Ok a -> 
-            case rb of 
-                Err x -> Err x
-                Ok b ->
-                    case rc of 
-                        Err x -> Err x
-                        Ok c -> 
-                            case rd of 
-                                Err x -> Err x
-                                Ok d -> 
-                                    case re of 
-                                        Err x -> Err x
-                                        Ok e ->
-                                            case rf of 
-                                                Err x -> Err x
-                                                Ok f -> 
-                                                    case rg of 
-                                                        Err x -> Err x
-                                                        Ok g ->
-                                                            case rh of 
-                                                                Err x -> Err x
-                                                                Ok h ->
-                                                                    case ri of 
-                                                                        Err x -> Err x
-                                                                        Ok i ->
-                                                                            case rj of 
-                                                                                Err x -> Err x
-                                                                                Ok j -> Ok $ fn a b c d e f g h i j
+  fn <$> ra <*> rb <*> rc <*> rd <*> re <*> rf <*> rg <*> rh <*> ri <*> rj
 
+map11 fn r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 =
+  fn <$> r1 <*> r2 <*> r3 <*> r4 <*> r5 <*> r6 <*> r7 <*> r8 <*> r9 <*> r10 <*> r11
+
+map12 fn r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 =
+  fn <$> r1 <*> r2 <*> r3 <*> r4 <*> r5 <*> r6 <*> r7 <*> r8 <*> r9 <*> r10 <*> r11 <*> r12
+
+map13 fn r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 =
+  fn <$> r1 <*> r2 <*> r3 <*> r4 <*> r5 <*> r6 <*> r7 <*> r8 <*> r9 <*> r10 <*> r11 <*> r12 <*> r13
+
+map14 fn r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14 =
+  fn <$> r1 <*> r2 <*> r3 <*> r4 <*> r5 <*> r6 <*> r7 <*> r8 <*> r9 <*> r10 <*> r11 <*> r12 <*> r13 <*> r14
+
+map15 fn r1 r2 r3 r4 r5 r6 r7 r8 r9 r10 r11 r12 r13 r14 r15  =
+  fn <$> r1 <*> r2 <*> r3 <*> r4 <*> r5 <*> r6 <*> r7 <*> r8 <*> r9 <*> r10 <*> r11 <*> r12 <*> r13 <*> r14 <*> r15
 
 andThen :: (a -> Result x b) -> Result x a -> Result x b
 andThen callback result =

--- a/ServerTemplate/src/Static/Task.hs
+++ b/ServerTemplate/src/Static/Task.hs
@@ -128,7 +128,7 @@ instance Applicative (Task e) where
 instance Monad (Task e) where
     return = succeed
     (>>=) = flip andThen
-
+    
 instance MonadError e (Task e) where
     throwError = Static.Task.fail
     catchError = flip Static.Task.onError

--- a/ServerTemplate/src/Static/Task.hs
+++ b/ServerTemplate/src/Static/Task.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE InstanceSigs #-}
-
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 module Static.Task where
 
@@ -127,6 +129,6 @@ instance Monad (Task e) where
     return = succeed
     (>>=) = flip andThen
 
-instance MonadError (Task e) where
-    throwError = fail
-    catchError = onError
+instance MonadError e (Task e) where
+    throwError = Static.Task.fail
+    catchError = flip Static.Task.onError

--- a/ServerTemplate/src/Static/Task.hs
+++ b/ServerTemplate/src/Static/Task.hs
@@ -8,6 +8,7 @@ import Static.ServerTypes
 --import Static.Cmd
 import Utils.Utils
 import Control.Monad (foldM)
+import Control.Monad.Except
 import Data.Maybe (fromJust)
 import Data.TMap as TM
 import Static.Cmd as Cmd (Cmd(..))
@@ -125,3 +126,7 @@ instance Applicative (Task e) where
 instance Monad (Task e) where
     return = succeed
     (>>=) = flip andThen
+
+instance MonadError (Task e) where
+    throwError = fail
+    catchError = onError


### PR DESCRIPTION
Some interesting external references:
  - https://www.schoolofhaskell.com/user/griba/elm-from-a-haskell-perspective describes Elm from a Haskell perspective, which might be useful.
  - http://www.staff.city.ac.uk/~ross/papers/Applicative.pdf is an introduction to Applicative programming, with motivations and examples.

This PR will:
 - Make Result a monad! This strictly isn't needed however.
 - Rewrite `mapn` functions using the applicative programming paradigm `f <$> r1 <*> ... <*> rn`. The referenced paper explains this in detail. Elm deliberately avoids this, but this is a useful pattern to know, and provides much shorter code than the nested cases we have now! We can consider using this pattern in encoding and decoding as well, as mentioned by @CSchank.
 - Minor addition: Made Task an instance of MonadError as well. Probably will not grant any new benefits other than being able to use the typeclass functions.

Questions to consider:
 - We're starting to apply Haskell concepts of typeclasses and Monads to Elm constructs. Will this pollute the design space of this framework? An argument can be made to stick to Elm programming constructs so we don't confuse beginners. One nice thing about how we're doing things now is Elm programmers can still use their familiar functions, but if they wanted they can switch to using Monads and Applicatives.
- Commands were brought up in several discussions. They currently have the necessary parts to be made into a Monad, since they're a wrapper around IO. The Elm Architecture however, deliberately exposes Commands with a Functor interface only. For now I think we should not make Commands as Monads, since we have Tasks for that.