### PR TITLE
allow client to send command (not returning any msg atm though)

### DIFF
--- a/ClientTemplate/app/Main.elm
+++ b/ClientTemplate/app/Main.elm
@@ -211,7 +211,7 @@ update msg model =
             let 
                 (newAppModel, mCmd) = Static.Update.update () incomingMsg model.appModel 
             in
-                { model | appModel = newAppModel } |> withNoCmd
+                ({ model | appModel = newAppModel }, Cmd.map (always NoOp) mCmd)
         OutgoingTrans trans ->
             let
                 respTxt = encodeTransition trans

--- a/ClientTemplate/app/Main.elm
+++ b/ClientTemplate/app/Main.elm
@@ -211,7 +211,7 @@ update msg model =
             let 
                 (newAppModel, mCmd) = Static.Update.update () incomingMsg model.appModel 
             in
-                ({ model | appModel = newAppModel }, Cmd.map (always NoOp) mCmd)
+                { model | appModel = newAppModel } |> withCmd (Cmd.map Static.Update.outgoingToIncoming mCmd)
         OutgoingTrans trans ->
             let
                 respTxt = encodeTransition trans


### PR DESCRIPTION
I'm trying to open a new window to view the resume. This requires sending a command to javascript port, so we temporarily need a change in the template like this. 
The result can be found here: https://github.com/christopheranand/NewYouthHack/commit/898b5cb61b3e89c5f77f3f734e71344b7194cad0
Go to resume creator room, click `View Resume` will open a new window.