### PR TITLE
use normal forkIO instead of Control.Concurrent.Thread.forkIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ elm-stuff/
 elm-haskell-state-diagram.cabal
 dist/
 *.cabal
+.templates

--- a/ServerTemplate/src/Static/ServerLogic.hs
+++ b/ServerTemplate/src/Static/ServerLogic.hs
@@ -12,7 +12,7 @@ import           Data.Text              (Text)
 import           Control.Monad.IO.Class         (liftIO)
 import qualified Data.Text              as T
 import qualified Network.WebSockets     as WS
-import           Control.Concurrent     (forkIO, result)
+import           Control.Concurrent     (forkIO)
 import           Control.Concurrent.Async       (race_)
 import           Control.Exception      (finally)
 import qualified Data.Time.Clock.POSIX         as Time

--- a/ServerTemplate/src/Static/ServerLogic.hs
+++ b/ServerTemplate/src/Static/ServerLogic.hs
@@ -12,7 +12,7 @@ import           Data.Text              (Text)
 import           Control.Monad.IO.Class         (liftIO)
 import qualified Data.Text              as T
 import qualified Network.WebSockets     as WS
-import           Control.Concurrent.Thread      (forkIO, result)
+import           Control.Concurrent     (forkIO, result)
 import           Control.Concurrent.Async       (race_)
 import           Control.Exception      (finally)
 import qualified Data.Time.Clock.POSIX         as Time

--- a/src/Generate/Plugins.hs
+++ b/src/Generate/Plugins.hs
@@ -32,7 +32,7 @@ generatePlugins fp extraTypes net ps =
             ,   "import Control.Concurrent.STM (TQueue, atomically, writeTQueue)"
             ,   "import           Control.Monad          (void)"
             ,   "import Data.Maybe (fromJust)"
-            ,   "import Control.Concurrent.Thread (forkIO, result)\n"
+            ,   "import Control.Concurrent     (forkIO)"
             ,   T.concat $ map (\p -> case p of 
                                     Plugin n -> T.concat["import qualified Plugins.",n,"\n"]
                                     PluginGen n _ -> T.concat["import qualified Plugins.",n,"\n"]

--- a/src/Generate/Plugins.hs
+++ b/src/Generate/Plugins.hs
@@ -32,7 +32,7 @@ generatePlugins fp extraTypes net ps =
             ,   "import Control.Concurrent.STM (TQueue, atomically, writeTQueue)"
             ,   "import           Control.Monad          (void)"
             ,   "import Data.Maybe (fromJust)"
-            ,   "import Control.Concurrent     (forkIO)"
+            ,   "import Control.Concurrent.Thread     (forkIO, result)"
             ,   T.concat $ map (\p -> case p of 
                                     Plugin n -> T.concat["import qualified Plugins.",n,"\n"]
                                     PluginGen n _ -> T.concat["import qualified Plugins.",n,"\n"]


### PR DESCRIPTION
We're not waiting for the result of the thread, so no need to use `Control.Concurrent.Thread.forkIO`. Also if we might use it in the future it is recommended to do `qualified` import.